### PR TITLE
Better user input and timeouts

### DIFF
--- a/web-app/app/api/query/route.ts
+++ b/web-app/app/api/query/route.ts
@@ -1,14 +1,14 @@
 import { NextRequest, NextResponse } from 'next/server'
 import {handleQuery} from '@/engine/utils/query'
-import { EMBEDDING_MODEL } from '@/engine/types';
+import { DATASET, EMBEDDING_MODEL } from '@/engine/types';
 
 // Routes on the free plan timeout after 5 seconds (504 - error).
 export async function POST(request: NextRequest) {
     const body = await request.json()
-    const {query, modelsToRetrieveDocs, generateAnswer} = body;
+    const {query, modelsToRetrieveDocs, generateAnswer, datasets} = body;
 
 
-    // Get embedding models list from dictionary of toggles
+    // Get embedding models list from dictionary of toggles.
     let embeddingModels = [];
     if (modelsToRetrieveDocs) {
         for (let model in modelsToRetrieveDocs) {
@@ -18,12 +18,26 @@ export async function POST(request: NextRequest) {
         }
     }
 
+    // Get datasets to filter the result set from from dictionary of toggles.
+    let filterDatasets: DATASET[] | null = [];
+    if (datasets) {
+        for (let dataset in datasets) {
+            if (body.datasets[dataset]) {
+                filterDatasets.push(dataset as DATASET);
+            }
+        }
+    }
+    if (filterDatasets.length == 0) {
+        filterDatasets = null;
+    }
+    console.log(`filterDatasets: ${filterDatasets}`);
+
     // If we are generating an answer, include "no model" as well.
     if (generateAnswer) {
         embeddingModels.push(null);
     }
 
-    const queryResult = await handleQuery(query, embeddingModels, generateAnswer)
+    const queryResult = await handleQuery(query, embeddingModels, filterDatasets, generateAnswer)
 
     return NextResponse.json(queryResult);
 }

--- a/web-app/app/api/query/route.ts
+++ b/web-app/app/api/query/route.ts
@@ -5,7 +5,7 @@ import { DATASET, EMBEDDING_MODEL } from '@/engine/types';
 // Routes on the free plan timeout after 5 seconds (504 - error).
 export async function POST(request: NextRequest) {
     const body = await request.json()
-    const {query, modelsToRetrieveDocs, generateAnswer, datasets} = body;
+    const { query, modelsToRetrieveDocs, generateAnswer, datasets, maxDocuments } = body;
 
 
     // Get embedding models list from dictionary of toggles.
@@ -30,14 +30,13 @@ export async function POST(request: NextRequest) {
     if (filterDatasets.length == 0) {
         filterDatasets = null;
     }
-    console.log(`filterDatasets: ${filterDatasets}`);
 
     // If we are generating an answer, include "no model" as well.
     if (generateAnswer) {
         embeddingModels.push(null);
     }
 
-    const queryResult = await handleQuery(query, embeddingModels, filterDatasets, generateAnswer)
+    const queryResult = await handleQuery(query, embeddingModels, filterDatasets, maxDocuments, generateAnswer)
 
     return NextResponse.json(queryResult);
 }

--- a/web-app/app/page.tsx
+++ b/web-app/app/page.tsx
@@ -61,6 +61,7 @@ export default function Home() {
         query: query,
         generateAnswer: generateAnswer,
         modelsToRetrieveDocs: embeddingChoices,
+        datasets: datasetsChoices,
       }),
     });
 

--- a/web-app/app/page.tsx
+++ b/web-app/app/page.tsx
@@ -13,6 +13,9 @@ import {
 } from "@/engine/types";
 import { FormEvent, useState } from "react";
 
+const DEFAULT_MAX_DOCUMENTS: number = 5;
+const MAX_DOCUMENTS_UPPER_BOUND: number = 20;
+
 // Used for determinstic ordering of models / results.
 const modelSorter = (model1: string | null, model2: string | null) => {
   const idx1 = model1 ? enabledEmbeddingModels.indexOf(EMBEDDING_MODEL[model1 as keyof typeof EMBEDDING_MODEL]) : -1;
@@ -45,12 +48,19 @@ export default function Home() {
   const [loading, setLoading] = useState<boolean>(false);
   const [uploadText, setUploadText] = useState<string>("");
   const [formState, setFormState] = useState<string>("Search");
+  const [maxDocuments, setMaxDocuments] = useState<number>(DEFAULT_MAX_DOCUMENTS);
 
   async function runQuery() {
     if (!query) {
-      alert("Please enter a query");
+      alert("Please enter a query.");
       return;
     }
+
+    if (!Number.isInteger(maxDocuments) || maxDocuments <= 0 || maxDocuments > MAX_DOCUMENTS_UPPER_BOUND) {
+      alert(`Please enter a value between 1 and ${MAX_DOCUMENTS_UPPER_BOUND} for the number of documents to fetch.`);
+      return;
+    }
+
     setLoading(true);
     const response = await fetch("/api/query", {
       method: "POST",
@@ -62,6 +72,7 @@ export default function Home() {
         generateAnswer: generateAnswer,
         modelsToRetrieveDocs: embeddingChoices,
         datasets: datasetsChoices,
+        maxDocuments: maxDocuments,
       }),
     });
 
@@ -73,6 +84,10 @@ export default function Home() {
   const handleCheckboxChange = () => {
     setGenerateAnswer(!generateAnswer);
   };
+
+  const handleMaxDocumentsChange = (event: FormEvent<HTMLInputElement>) => {
+    setMaxDocuments(Number(event.currentTarget.value));
+  }
 
   const handleQueryChange = (event: FormEvent<HTMLInputElement>) => {
     setQuery(event.currentTarget.value);
@@ -304,13 +319,27 @@ export default function Home() {
                 {/* Additional options */}
                 <div className="leading-6 mt-2">
                   <p className="font-bold">Extra:</p>
-                  <input
-                    type="checkbox"
-                    className="h-4 w-4 rounded border-gray-300 text-emerald-600 focus:ring-emerald-600"
-                    checked={generateAnswer}
-                    onChange={handleCheckboxChange}
-                  />
-                  <label className="ml-2">Generate an Answer (RAG)?</label>
+                  <div>
+                    <input
+                      type="checkbox"
+                      className="h-4 w-4 rounded border-gray-300 text-emerald-600 focus:ring-emerald-600"
+                      checked={generateAnswer}
+                      onChange={handleCheckboxChange}
+                    />
+                    <label className="ml-2">Generate an Answer (RAG)?</label>
+                  </div>
+                  <div>
+                    <input
+                      type="number"
+                      min="1"
+                      max={MAX_DOCUMENTS_UPPER_BOUND}
+                      step="1"
+                      className="h-8 rounded border-gray-300 focus:ring-emerald-600"
+                      value={maxDocuments}
+                      onChange={handleMaxDocumentsChange}
+                    />
+                    <label className="ml-2">Number of Documents to Fetch</label>
+                  </div>
                 </div>
               </div>
             </div>

--- a/web-app/engine/clients/baseten.ts
+++ b/web-app/engine/clients/baseten.ts
@@ -24,6 +24,5 @@ export const getInstructorLargeEmbeddings = async (inputs: string[]) => {
 
 
 export const getMPNETBaseEmbeddings = async (inputs: string[]) => {
-    console.log("getMPNETBaseEmbeddings from baseten!!")
     return await getBasetenEmbeddings(inputs, 'ZBAg31P')
 }

--- a/web-app/engine/clients/supabase.ts
+++ b/web-app/engine/clients/supabase.ts
@@ -45,7 +45,6 @@ export const getNearestDocumentsFromSupabase = async (
     console.log(`Expected vector of dim ${expectedDim} but got ${queryEmbedding.length}!`);
     return [];
   }
-  console.log(`Datasets: ${filterDatasets}`);
 
   const supabaseFunc = `nearest_documents_for_datasets_${expectedDim}`;
   const { data: results, error } = await supabaseClient.rpc(

--- a/web-app/engine/clients/supabase.ts
+++ b/web-app/engine/clients/supabase.ts
@@ -37,6 +37,7 @@ export const uploadEmbeddingsToSupabase = async (
 export const getNearestDocumentsFromSupabase = async (
   queryEmbedding: number[],
   embeddingModel: EMBEDDING_MODEL,
+  filterDatasets: DATASET[] | null,
   maxMatches: number
 ) => {
   const expectedDim = getEmbeddingDimensionForModel(embeddingModel);
@@ -44,13 +45,15 @@ export const getNearestDocumentsFromSupabase = async (
     console.log(`Expected vector of dim ${expectedDim} but got ${queryEmbedding.length}!`);
     return [];
   }
+  console.log(`Datasets: ${filterDatasets}`);
 
-  const supabaseFunc = `nearest_documents_${expectedDim}`;
+  const supabaseFunc = `nearest_documents_for_datasets_${expectedDim}`;
   const { data: results, error } = await supabaseClient.rpc(
     supabaseFunc,
     {
       query_embedding: queryEmbedding,
       query_embedding_model: EMBEDDING_MODEL[embeddingModel],
+      query_datasets: filterDatasets,
       max_matches: maxMatches,
     }
   );

--- a/web-app/engine/types.ts
+++ b/web-app/engine/types.ts
@@ -52,10 +52,12 @@ export const userFriendlyNameByModel = new Map(Object.entries({
 
 export const enabledDatasets = [
     DATASET.WIKIPEDIA,
+    DATASET.CUSTOM,
 ];
 
 export const userFriendlyNameByDataset = new Map(Object.entries({
     [DATASET.WIKIPEDIA]: "Wikipedia",
+    [DATASET.CUSTOM]: "Uploaded Data",
 }));
 
 export enum LANGUAGE_MODEL {

--- a/web-app/engine/utils/database.ts
+++ b/web-app/engine/utils/database.ts
@@ -16,11 +16,12 @@ export const uploadEmbeddings = async (
 export const fetchNearestDocuments = async (
     queryEmbedding: number[],
     embeddingModel: EMBEDDING_MODEL,
+    filterDatasets: DATASET[] | null,
     maxMatches: number,
     database: DATABASE
 ) => {
     switch (database as DATABASE) {
         case DATABASE.SUPABASE:
-            return await getNearestDocumentsFromSupabase(queryEmbedding, embeddingModel, maxMatches);
+            return await getNearestDocumentsFromSupabase(queryEmbedding, embeddingModel, filterDatasets, maxMatches);
     }
 }

--- a/web-app/engine/utils/embedding.ts
+++ b/web-app/engine/utils/embedding.ts
@@ -51,6 +51,17 @@ export const getEmbedding = async (input: string, embeddingModel: EMBEDDING_MODE
     }
 }
 
+export const getEmbeddingWithTimeLimit = async (input: string, embeddingModel: EMBEDDING_MODEL, timeLimitInMilliseconds: number) => {
+    const embeddingPromise = getEmbedding(input, embeddingModel);
+    const timeLimitPromise = new Promise((resolve, reject) => {
+        const timeout = setTimeout(() => {
+            resolve(null);
+        }, timeLimitInMilliseconds);
+    });
+    const embedding = await Promise.race([embeddingPromise, timeLimitPromise]);
+    return embedding as number[];
+}
+
 export const embedTextChunks = async (
     textChunks: TextChunk[], embeddingModel: EMBEDDING_MODEL, batchSize: number
 ) => {

--- a/web-app/engine/utils/query.ts
+++ b/web-app/engine/utils/query.ts
@@ -12,8 +12,6 @@ import { fetchNearestDocuments } from "./database";
 import { getEmbeddingWithTimeLimit } from "./embedding";
 import { getChatModelResponse } from "./inference";
 
-const DEFAULT_MAX_MATCHES: number = 5;
-
 // We wait 5 seconds for an embedding model response before timing out, due to cold start.
 const EMBEDDING_MODEL_TIME_LIMIT: number = 5000;
 
@@ -21,6 +19,7 @@ export const handleQuery = async (
   queryText: string,
   embeddingModels: (EMBEDDING_MODEL | null)[],
   filterDatasets: DATASET[] | null,
+  maxDocuments: number,
   generateAnswer: boolean = true,
 ) => {
   let data: QueryData[] = [];
@@ -40,7 +39,7 @@ export const handleQuery = async (
             queryEmbedding,
             embeddingModel,
             filterDatasets,
-            DEFAULT_MAX_MATCHES,
+            maxDocuments,
             DATABASE.SUPABASE
           );
           documents = fetchedDocuments;

--- a/web-app/engine/utils/query.ts
+++ b/web-app/engine/utils/query.ts
@@ -9,10 +9,13 @@ import {
 } from "../types";
 import { secondsFrom } from "./clock";
 import { fetchNearestDocuments } from "./database";
-import { getEmbedding } from "./embedding";
+import { getEmbeddingWithTimeLimit } from "./embedding";
 import { getChatModelResponse } from "./inference";
 
 const DEFAULT_MAX_MATCHES: number = 5;
+
+// We wait 5 seconds for an embedding model response before timing out, due to cold start.
+const EMBEDDING_MODEL_TIME_LIMIT: number = 5000;
 
 export const handleQuery = async (
   queryText: string,
@@ -27,7 +30,7 @@ export const handleQuery = async (
     let modelResponse: string = "";
     if (embeddingModel) {
       const embeddingStartTime = Date.now();
-      const queryEmbedding = await getEmbedding(queryText, embeddingModel);
+      const queryEmbedding = await getEmbeddingWithTimeLimit(queryText, embeddingModel, EMBEDDING_MODEL_TIME_LIMIT);
       console.log(`Retrieved query embedding from ${embeddingModel} in ${secondsFrom(embeddingStartTime)} seconds`);
       
       if (queryEmbedding) {

--- a/web-app/engine/utils/query.ts
+++ b/web-app/engine/utils/query.ts
@@ -17,7 +17,8 @@ const DEFAULT_MAX_MATCHES: number = 5;
 export const handleQuery = async (
   queryText: string,
   embeddingModels: (EMBEDDING_MODEL | null)[],
-  generateAnswer: boolean = true
+  filterDatasets: DATASET[] | null,
+  generateAnswer: boolean = true,
 ) => {
   let data: QueryData[] = [];
   
@@ -35,6 +36,7 @@ export const handleQuery = async (
           const fetchedDocuments = await fetchNearestDocuments(
             queryEmbedding,
             embeddingModel,
+            filterDatasets,
             DEFAULT_MAX_MATCHES,
             DATABASE.SUPABASE
           );

--- a/web-app/supabase/migrations/20231006185359_test_filtering_by_dataset.sql
+++ b/web-app/supabase/migrations/20231006185359_test_filtering_by_dataset.sql
@@ -1,0 +1,26 @@
+create function nearest_documents_for_datasets_1536 (
+  query_embedding vector(1536),
+  query_embedding_model text,
+  query_datasets text[],
+  max_matches int
+)
+returns table (
+    dataset text,
+    document text,
+    similarity float
+)
+language plpgsql
+as $$
+begin
+  return query
+  select
+    embeddings.dataset,
+    embeddings.document,
+    1 - (embeddings.embedding_1536 <=> query_embedding) as similarity
+  from embeddings
+  where embeddings.embedding_model = query_embedding_model
+  and (query_datasets is null or embeddings.dataset = ANY(query_datasets))
+  order by (embeddings.embedding_1536 <=> query_embedding) asc
+  limit max_matches;
+end;
+$$;

--- a/web-app/supabase/migrations/20231006224901_other_embedding_dims.sql
+++ b/web-app/supabase/migrations/20231006224901_other_embedding_dims.sql
@@ -1,0 +1,53 @@
+create function nearest_documents_for_datasets_1024 (
+  query_embedding vector(1024),
+  query_embedding_model text,
+  query_datasets text[],
+  max_matches int
+)
+returns table (
+    dataset text,
+    document text,
+    similarity float
+)
+language plpgsql
+as $$
+begin
+  return query
+  select
+    embeddings.dataset,
+    embeddings.document,
+    1 - (embeddings.embedding_1024 <=> query_embedding) as similarity
+  from embeddings
+  where embeddings.embedding_model = query_embedding_model
+  and (query_datasets is null or embeddings.dataset = ANY(query_datasets))
+  order by (embeddings.embedding_1024 <=> query_embedding) asc
+  limit max_matches;
+end;
+$$;
+
+create function nearest_documents_for_datasets_768 (
+  query_embedding vector(768),
+  query_embedding_model text,
+  query_datasets text[],
+  max_matches int
+)
+returns table (
+    dataset text,
+    document text,
+    similarity float
+)
+language plpgsql
+as $$
+begin
+  return query
+  select
+    embeddings.dataset,
+    embeddings.document,
+    1 - (embeddings.embedding_768 <=> query_embedding) as similarity
+  from embeddings
+  where embeddings.embedding_model = query_embedding_model
+  and (query_datasets is null or embeddings.dataset = ANY(query_datasets))
+  order by (embeddings.embedding_768 <=> query_embedding) asc
+  limit max_matches;
+end;
+$$;


### PR DESCRIPTION
- Let users specify number of documents to fetch
- Actually filter retrieved documents by the datasets selected in UI
- Set a 5 second time limit on generating query embedding to avoid hanging due to model cold start